### PR TITLE
fix: fix config.name

### DIFF
--- a/.socialgouv/config.json
+++ b/.socialgouv/config.json
@@ -1,5 +1,5 @@
 {
-  "name": "nos1000jours-web-pro",
+  "name": "nos1000jours-blues-epds-pro",
   "type": "app",
   "registry": "ghcr",
   "project": "nos1000jours"


### PR DESCRIPTION
Apparemment ce nom doit fitter avec le nom du repo (ca impacte le nom des images docker utilisées)