### PR TITLE
fix(secu): use non-privilegied docker user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,6 @@ USER node
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
+USER 1000
+
 CMD ["yarn", "start"]


### PR DESCRIPTION
Ceci permet de forcer un user non privilégié pour faire tourner le container docker